### PR TITLE
ros-caffe-ssd

### DIFF
--- a/docker/ros-caffe-ssd/Dockerfile
+++ b/docker/ros-caffe-ssd/Dockerfile
@@ -1,4 +1,6 @@
 # This image build for cuda8.0 + cudnn7 + ros kinetic
+# docker pull built image: peterx7803/ros-caffe-ssd
+
 FROM nvidia/cuda:8.0-cudnn7-devel-ubuntu16.04
 
 # Set default shell to bash
@@ -18,9 +20,13 @@ RUN wget -q https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py && \
     export PATH=/usr/local/bin:$PATH && \
     rm get-pip.py
-    
+
+RUN pip install --upgrade pip
+
 # RUN git clone https://github.com/voutcn/g2o.git && cd g2o && sh init.sh
-RUN pip install -q -U bitarray pyzmq ujson requests gunicorn pymysql numpy pandas scipy scikit-learn gTTs awscli numba chardet > /dev/null
+
+# ADD pip install pyopenssl before ROS install to fix build issue
+RUN pip install -q -U bitarray pyzmq ujson requests gunicorn pymysql numpy pandas scipy scikit-learn gTTs awscli numba chardet pyopenssl > /dev/null
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' && \
     apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116 && \
     apt-get update -qq && \
@@ -63,8 +69,8 @@ ENV CAFFE_ROOT=/opt/caffe
 WORKDIR $CAFFE_ROOT
 # FIXME: use ARG instead of ENV once DockerHub supports this
 # https://github.com/docker/hub-feedback/issues/460
-ENV CLONE_TAG=1.0
-RUN git clone -b ${CLONE_TAG} --depth 1 https://github.com/BVLC/caffe.git . && \
+ENV CLONE_TAG=ssd
+RUN git clone -b ${CLONE_TAG} --depth 1 https://github.com/weiliu89/caffe . && \
     pip install --upgrade pip && \
     cd python && for req in $(cat requirements.txt) pydot; do pip install $req; done && cd .. && \
     git clone https://github.com/NVIDIA/nccl.git && cd nccl && make -j install && cd .. && rm -rf nccl && \
@@ -78,20 +84,4 @@ RUN echo "$CAFFE_ROOT/build/lib" >> /etc/ld.so.conf.d/caffe.conf && ldconfig
 WORKDIR /workspace
 RUN sudo pip install jupyter
 #  -------------------------------------------------- caffe --------------------------------------------------
-
-# -------------------------------------------------- Tensorlow -----------------------------------------------
-#RUN mkdir -p /tensorflow/models
-#RUN apt-get install -y git python-pip
-#RUN pip install tensorflow
-#RUN pip install lxml
-#RUN apt-get install -y protobuf-compiler python-pil #python-lxml
-#RUN pip install jupyter
-#RUN pip install matplotlib
-
-# -------------------------------------------------- Tensorflow --------------------------------------------------
-
-# Define default command.
-# COPY ./ros_entrypoint.sh /
-# ENTRYPOINT ["/ros_entrypoint.sh"]
-# CMD [/bin/bash -c "source /opt/ros/kinetic/setup.bash"]
 


### PR DESCRIPTION
Dockerfile for caffe-ros-ssd
Built image could pull by "docker pull peterx7803/ros-caffe-ssd"

![image](https://user-images.githubusercontent.com/21194463/48315485-c80e1a00-e611-11e8-8489-f26ee5be10f9.png)

If want to train SSD on workstation, need to modify examples/ssd/ssd_pascal.py:
Line 332 gpus = "0，1，2，3" to "0"
Line 337 batch_size = 32 to batch_size = 16
Line 338 accum_batch_size = 32 to accum_batch_size = 16
